### PR TITLE
Improve match criteria

### DIFF
--- a/feedme/FeedMe/ElementTypes/CategoryFeedMeElementType.php
+++ b/feedme/FeedMe/ElementTypes/CategoryFeedMeElementType.php
@@ -47,7 +47,7 @@ class CategoryFeedMeElementType extends BaseFeedMeElementType
         $criteria->status = null;
         $criteria->limit = null;
         $criteria->localeEnabled = null;
-        
+
         $criteria->groupId = $settings['elementGroup']['Category'];
 
         return $criteria;
@@ -60,7 +60,17 @@ class CategoryFeedMeElementType extends BaseFeedMeElementType
                 $feedValue = Hash::get($data, $handle . '.data', $data[$handle]);
 
                 if ($feedValue) {
-                    $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    if (is_array($feedValue)) {
+                        // Value must be the ids of related elements.
+                        if (empty($criteria->relatedTo)) {
+                            $criteria->relatedTo = ['and'];
+                        }
+
+                        $criteria->relatedTo = array_merge($criteria->relatedTo, $feedValue);
+                    }
+                    else {
+                        $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    }
                 }
             }
         }
@@ -73,7 +83,7 @@ class CategoryFeedMeElementType extends BaseFeedMeElementType
     {
         return craft()->categories->deleteCategory($elements);
     }
-    
+
     public function prepForElementModel(BaseElementModel $element, array &$data, $settings)
     {
         foreach ($data as $handle => $value) {

--- a/feedme/FeedMe/ElementTypes/EntryFeedMeElementType.php
+++ b/feedme/FeedMe/ElementTypes/EntryFeedMeElementType.php
@@ -86,7 +86,17 @@ class EntryFeedMeElementType extends BaseFeedMeElementType
                 }
 
                 if ($feedValue) {
-                    $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    if (is_array($feedValue)) {
+                        // Value must be the ids of related elements.
+                        if (empty($criteria->relatedTo)) {
+                            $criteria->relatedTo = ['and'];
+                        }
+
+                        $criteria->relatedTo = array_merge($criteria->relatedTo, $feedValue);
+                    }
+                    else {
+                        $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    }
                 }
             }
         }
@@ -218,7 +228,7 @@ class EntryFeedMeElementType extends BaseFeedMeElementType
             $criteria = craft()->elements->getCriteria(ElementType::User);
             $criteria->search = $author;
             $authorUser = $criteria->first();
-            
+
             if ($authorUser) {
                 $author = $authorUser->id;
             } else {

--- a/feedme/FeedMe/ElementTypes/UserFeedMeElementType.php
+++ b/feedme/FeedMe/ElementTypes/UserFeedMeElementType.php
@@ -54,7 +54,7 @@ class UserFeedMeElementType extends BaseFeedMeElementType
         $criteria->limit = null;
         //$criteria->group = null;
         $criteria->localeEnabled = null;
-        
+
         if ($settings['locale']) {
             $criteria->locale = $settings['locale'];
         }
@@ -69,7 +69,17 @@ class UserFeedMeElementType extends BaseFeedMeElementType
                 $feedValue = Hash::get($data, $handle . '.data', $data[$handle]);
 
                 if ($feedValue) {
-                    $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    if (is_array($feedValue)) {
+                        // Value must be the ids of related elements.
+                        if (empty($criteria->relatedTo)) {
+                            $criteria->relatedTo = ['and'];
+                        }
+
+                        $criteria->relatedTo = array_merge($criteria->relatedTo, $feedValue);
+                    }
+                    else {
+                        $criteria->$handle = DbHelper::escapeParam($feedValue);
+                    }
                 }
             }
         }
@@ -137,7 +147,7 @@ class UserFeedMeElementType extends BaseFeedMeElementType
 
     public function afterSave(BaseElementModel $element, array $data, $settings)
     {
-        
+
     }
 
 

--- a/feedme/FeedMe/FieldTypes/CategoriesFeedMeFieldType.php
+++ b/feedme/FeedMe/FieldTypes/CategoriesFeedMeFieldType.php
@@ -48,7 +48,13 @@ class CategoriesFeedMeFieldType extends BaseFeedMeFieldType
             // Check if we've specified which attribute we're trying to match against
             $attribute = Hash::get($fieldData, 'options.match', 'title');
             $criteria->$attribute = DbHelper::escapeParam($category);
-            $elements = $criteria->ids();
+
+            // Check for additional attributes being matched against.
+            $extraAttributes = Hash::get($fieldData, 'options.matchExtra', []);
+
+            foreach ($extraAttributes as $attribute => $value) {
+                $criteria->$attribute = DbHelper::escapeParam($value);
+            }            
             
             $elements = $criteria->ids();
 

--- a/feedme/FeedMe/FieldTypes/EntriesFeedMeFieldType.php
+++ b/feedme/FeedMe/FieldTypes/EntriesFeedMeFieldType.php
@@ -61,6 +61,14 @@ class EntriesFeedMeFieldType extends BaseFeedMeFieldType
             // Check if we've specified which attribute we're trying to match against
             $attribute = Hash::get($fieldData, 'options.match', 'title');
             $criteria->$attribute = DbHelper::escapeParam($entry);
+
+            // Check for additional attributes being matched against.
+            $extraAttributes = Hash::get($fieldData, 'options.matchExtra', []);
+
+            foreach ($extraAttributes as $attribute => $value) {
+                $criteria->$attribute = DbHelper::escapeParam($value);
+            }            
+            
             $elements = $criteria->ids();
 
             $preppedData = array_merge($preppedData, $elements);

--- a/feedme/FeedMe/FieldTypes/UsersFeedMeFieldType.php
+++ b/feedme/FeedMe/FieldTypes/UsersFeedMeFieldType.php
@@ -12,7 +12,7 @@ class UsersFeedMeFieldType extends BaseFeedMeFieldType
     {
         return 'feedme/_includes/fields/users';
     }
-    
+
 
 
     // Public Methods
@@ -54,6 +54,14 @@ class UsersFeedMeFieldType extends BaseFeedMeFieldType
             // Check if we've specified which attribute we're trying to match against
             $attribute = Hash::get($fieldData, 'options.match', 'email');
             $criteria->$attribute = DbHelper::escapeParam($user);
+
+            // Check for additional attributes being matched against.
+            $extraAttributes = Hash::get($fieldData, 'options.matchExtra', []);
+
+            foreach ($extraAttributes as $attribute => $value) {
+                $criteria->$attribute = DbHelper::escapeParam($value);
+            }
+
             $elements = $criteria->ids();
 
             $preppedData = array_merge($preppedData, $elements);
@@ -127,5 +135,5 @@ class UsersFeedMeFieldType extends BaseFeedMeFieldType
             throw new Exception(json_encode($element->getErrors()));
         }
     }
-    
+
 }

--- a/feedme/services/FeedMe_ProcessService.php
+++ b/feedme/services/FeedMe_ProcessService.php
@@ -36,7 +36,7 @@ class FeedMe_ProcessService extends BaseApplicationComponent
         $return = $feed->attributes;
 
         // Set our start time to track feed processing time
-        $this->_time_start = microtime(true); 
+        $this->_time_start = microtime(true);
 
         // Add some additional information to our FeedModel - for ease of use in processing
         $return['fields'] = array();
@@ -94,8 +94,9 @@ class FeedMe_ProcessService extends BaseApplicationComponent
         // Set up a model for this Element Type
         $element = $this->_service->setModel($feed);
 
-        // Set criteria according to Element Type 
-        $criteria = $this->_criteria;
+        // Set criteria according to Element Type
+        // Note: base criteria must be refreshed to ensure it's not dirty from the previous step.
+        $criteria = clone $this->_criteria;
 
         // From the raw data in our feed, process it ready for mapping (more to do below)
         $data = $this->_data[$step];
@@ -161,7 +162,7 @@ class FeedMe_ProcessService extends BaseApplicationComponent
 
         $this->_debugOutput($element->attributes);
         $this->_debugOutput($fieldData);
-        
+
         // Save the element
         if ($this->_service->save($element, $fieldData, $feed)) {
             // Give elements a chance to perform actions after save
@@ -238,7 +239,7 @@ class FeedMe_ProcessService extends BaseApplicationComponent
 
         craft()->feedMe_process->finalizeAfterProcess($feedSettings, $feed);
     }
-    
+
 
 
     // Event Handlers


### PR DESCRIPTION
Hi Josh,

There are two commits in this pull request. 

Commit #9057078 addresses some bugs I found in matching feed record for updating where the match fields were Craft element types. 

In your match criteria, you are using ```$criteria->elementFieldHandle = [12]``` to indicate matching the IDs of Craft elements (entries, categories etc.). However, using that criteria format, I couldn't seem to get that to match any of my existing elements.  But changing it to use the ```relatedTo``` criteria attribute seemed to fix the matching of Craft element types.

Also, in the ```FeedMe_ProcessService```, doing some debugging I found that from step 2 onwards, the ```$criteria``` variable initialised in ```processFeed()``` seemed to somehow be 'polluted/dirty' with the criteria used on the previous step (i.e. some of the criteria values were values used in the previous step). I thought that it might be something to do with that ```$criteria``` variable being passed around by reference. So the fix I put in place was to initialize it with an actual clone of the Element Type's original base criteria. You may want to do some testing around this to verify if you get the same issue.

Commit #f2d257c is just a little addition I was hoping to have added in that in the future would support matching elements on additional element criteria attributes that have been programatically added using a plugin hook (which I will suggest in a future pull request). I have found this useful where the matching criteria needs to take into account special cases, such as where two elements have the same name etc. I have had success with programatically adding in some custom criteria to the ```matchExtra``` option (using a plugin hook) to ensure that the correct element is chosen as a match in special cases.

Let me know your thoughts.



