### PR TITLE
Add active/inactive values as parseBoolean helpers

### DIFF
--- a/feedme/FeedMe/Helpers/FeedMeHelper.php
+++ b/feedme/FeedMe/Helpers/FeedMeHelper.php
@@ -31,7 +31,6 @@ class FeedMeHelper
             $result = true;
         }
 
-
         if (strtolower($value) === Craft::t('no')) {
             $result = false;
         }
@@ -45,6 +44,14 @@ class FeedMeHelper
         }
 
         if (strtolower($value) === Craft::t('disabled')) {
+            $result = false;
+        }
+
+        if (strtolower($value) === Craft::t('active')) {
+            $result = true;
+        }
+
+        if (strtolower($value) === Craft::t('inactive')) {
             $result = false;
         }
 


### PR DESCRIPTION
@engram-design In a feed we have a field being mapped to entry status, but it has the values of Active/Inactive. Currently this isn't matched by FeedMe, so I've added it to the boolean helpers list. It is bespoke to this feed, but it seems quite a logical value to have on a general basis? Would you considering have this included upstream?