### PR TITLE
Allow custom entry fields to be used in entry mapping (Craft 2)

### DIFF
--- a/feedme/templates/_includes/fields/entries.html
+++ b/feedme/templates/_includes/fields/entries.html
@@ -28,13 +28,22 @@
                 <div class="element-match">
                     <span>{{ 'Data provided for this entry is:' | t }}</span>
 
+                    {% set defaultFieldOptions = [
+                        { value: 'title', label: 'Title' | t },
+                        { value: 'id', label: 'ID' | t},
+                        { value: 'slug', label: 'Slug' | t},
+                    ] %}
+
+                    {% set customFieldOptions = [] %}
+                    {% for field in craft.fields.getAllFields() %}
+                        {% if field.type == "PlainText" %}
+                            {% set customFieldOptions = customFieldOptions|merge({(field.handle) : field.name}) %}
+                        {% endif %}
+                    {% endfor %}
+
                     {{ forms.selectField({
                         name: fieldHandle ~ '-options-match',
-                        options: [
-                            { value: 'title', label: 'Title' | t },
-                            { value: 'id', label: 'ID' | t },
-                            { value: 'slug', label: 'Slug' | t },
-                        ],
+                        options: defaultFieldOptions | merge(customFieldOptions),
                         value: feed.fieldMapping[fieldHandle ~ '-options-match'] ?? '',
                     }) }}
                 </div>
@@ -73,7 +82,7 @@
                 {# Lets not allow a few fields at this time - itself for recursive reasons, and Matrix because :O #}
                 {% if innerField.type in supportedSubElementFields and elementType != 'Entry' %}
                     {% set handleFieldPrefix = (handlePrefix is defined) ? handlePrefix : '' %}
-                    
+
                     {% set variables = {
                         field: innerField,
                         feed: feed,
@@ -83,7 +92,7 @@
                         labelHandle: innerField.handle,
                         isSubElementField: true,
                     } %}
-                    
+
                     {% include 'feedme/_includes/field' with variables %}
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
@engram-design Just floating this as an idea. I've come across an issue where I cannot map an item in a feed using the entry default `id`, `title`, `slug` options, because the data cannot match any of those fields, as I'm not in control of the data schema. 

I have had to shamefully modify the `_includes/fields` templates to provide the custom field I need to use for this specific feed item for it to work. This got my thinking it would be nice for entry mapping to be able to also use all the custom fields within the Craft site, rather than just the default three provided.

After a bit of debugging, I was able to split the options array into `defaultFieldOptions` and `customFieldOptions` and then merge them together on the `forms.selectField`. I have limited the `customFieldOptions` array to only fields with a "PlainText" type, as I'd imagine there would be chaos with more exotic types.

Is this something you think could be worth including upstream? It seems to work OK, as this is simply appending more items to the original options array in the same format, except it its not hard coded anymore.