### PR TITLE
Fix incorrect instantiation of TagElement when creating new Users from a feed

### DIFF
--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -111,7 +111,7 @@ class Users extends Field implements FieldInterface
 
     private function _createElement($dataValue, $groupId)
     {
-        $element = new TagElement();
+        $element = new UserElement();
         $element->email = $dataValue;
         $element->groupId = $groupId;
 


### PR DESCRIPTION
If I'm not mistaken, the object instantiated when trying to create a new User from a feed should be of type UserElement not TagElement.