### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/FeedMe.php
+++ b/src/FeedMe.php
@@ -110,6 +110,6 @@ class FeedMe extends Plugin
 
     private function _addTwigExtensions()
     {
-        Craft::$app->view->twig->addExtension(new Extension);
+        Craft::$app->view->registerTwigExtension(new Extension);
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.