### PR TITLE
added config option for csv delimiter

### DIFF
--- a/src/datatypes/Csv.php
+++ b/src/datatypes/Csv.php
@@ -25,11 +25,13 @@ class Csv extends DataType implements DataTypeInterface
     {
         $response = FeedMe::$plugin->data->getRawData($url);
 
+        $csvColumnDelimiter = FeedMe::$plugin->service->getConfig('csvColumnDelimiter') ?? ',';
+
         if (!$response['success']) {
             $error = 'Unable to reach ' . $url . '. Message: ' . $response['error'];
-            
+
             FeedMe::error($settings, $error);
-            
+
             return ['success' => false, 'error' => $error];
         }
 
@@ -46,6 +48,8 @@ class Csv extends DataType implements DataTypeInterface
             $data = StringHelper::convertToUtf8($data);
 
             $reader = Reader::createFromString($data);
+
+            $reader->setDelimiter($csvColumnDelimiter);
 
             $array = [];
 
@@ -72,7 +76,7 @@ class Csv extends DataType implements DataTypeInterface
 
         // Look for and return only the items for primary element
         $primaryElement = Hash::get($settings, 'primaryElement');
-        
+
         if ($primaryElement && $usePrimaryElement) {
             $array = FeedMe::$plugin->data->findPrimaryElement($primaryElement, $array);
         }


### PR DESCRIPTION
We needed an option to set the csv column delimiter to a different character, so i added a config option. Maybe this is useful for others as well?

Would be probably event more useful to be able to configure it on a per Import basis.

`csvColumnDelimiter` defaults to `,`