### PR TITLE
Use target locale when finding existing entries.

### DIFF
--- a/feedme/FeedMe/FieldTypes/EntriesFeedMeFieldType.php
+++ b/feedme/FeedMe/FieldTypes/EntriesFeedMeFieldType.php
@@ -60,6 +60,7 @@ class EntriesFeedMeFieldType extends BaseFeedMeFieldType
             $criteria->status = null;
             $criteria->sectionId = $sectionIds;
             $criteria->limit = $settings->limit;
+            $criteria->locale = $settings->targetLocale;
 
             // Check if we've specified which attribute we're trying to match against
             $attribute = Hash::get($fieldData, 'options.match', 'title');


### PR DESCRIPTION
This could do with more testing but it fixed an issue for me where Feed Me wasn’t finding existing entries that weren’t in the default locale.

I had it set up to use the slug when finding, the field was set to use a secondary locale and the section containing the entires to be found was disabled in the primary locale and enabled in the secondary one.