### PR TITLE
Fixed 404 error when clearing logs.

### DIFF
--- a/feedme/controllers/FeedMe_LogsController.php
+++ b/feedme/controllers/FeedMe_LogsController.php
@@ -72,6 +72,6 @@ class FeedMe_LogsController extends BaseController
         $currentFullPath = craft()->path->getLogPath() . $this->_currentLogFileName;
         IOHelper::deleteFile($currentFullPath, true);
 
-        craft()->request->redirect('feedme/logs');
+        $this->redirect('feedme/logs');
     }
 }


### PR DESCRIPTION
Fixed 404 that would be thrown when clearing logs due to it not prepending the cp trigger e.g. admin.