### PR TITLE
Check that $enabledTabs is array before iteration

### DIFF
--- a/feedme/variables/FeedMeVariable.php
+++ b/feedme/variables/FeedMeVariable.php
@@ -47,8 +47,10 @@ class FeedMeVariable
 
         $selectedTabs = [];
 
-        foreach ($enabledTabs as $enabledTab) {
-            $selectedTabs[$enabledTab] = $tabs[$enabledTab];
+        if (is_array($enabledTabs)) {
+            foreach ($enabledTabs as $enabledTab) {
+                $selectedTabs[$enabledTab] = $tabs[$enabledTab];
+            }
         }
 
         return $selectedTabs;


### PR DESCRIPTION
On initial install, $enabledTabs is not an array and would throw an error. This prevented that error and allowed me to finish set up.