### PR TITLE
Clarify primary elements

### DIFF
--- a/feedme/templates/feeds/_edit.html
+++ b/feedme/templates/feeds/_edit.html
@@ -57,7 +57,7 @@
 
     {{ forms.textField({
         label: "Primary Element" | t,
-        instructions: "The primary element that contains the records you intend to parse. Selecting a Feed Type above will assist in most cases." | t,
+        instructions: "The primary elements that contain the records you intend to parse. Selecting a Feed Type above will assist in most cases." | t,
         id: 'primaryElement',
         class: 'code',
         name: 'primaryElement',


### PR DESCRIPTION
When this help text mentions a "primary element", a user might assume it is referring to a container object or root node (as I did). Pluralizing to "primary elements" could prevent this ambiguity.