### PR TITLE
Use Craft timezone on postDate/expiryDate fields

### DIFF
--- a/feedme/FeedMe/ElementTypes/EntryFeedMeElementType.php
+++ b/feedme/FeedMe/ElementTypes/EntryFeedMeElementType.php
@@ -195,13 +195,13 @@ class EntryFeedMeElementType extends BaseFeedMeElementType
             $this->parseInlineTwig($data, $dataValue);
 
             switch ($handle) {
-                case 'id';
+                case 'id':
                     $element->$handle = $dataValue;
                     break;
-                case 'authorId';
+                case 'authorId':
                     $element->$handle = $this->prepareAuthorForElement($dataValue);
                     break;
-                case 'slug';
+                case 'slug':
                     if (craft()->config->get('limitAutoSlugsToAscii')) {
                         $dataValue = StringHelper::asciiString($dataValue);
                     }
@@ -209,8 +209,10 @@ class EntryFeedMeElementType extends BaseFeedMeElementType
                     $element->$handle = ElementHelper::createSlug($dataValue);
                     break;
                 case 'postDate':
-                case 'expiryDate';
-                    $element->$handle = FeedMeDateHelper::parseString($dataValue);
+                case 'expiryDate':
+                    // https://github.com/verbb/feed-me/issues/388
+                    // Force postDate and expiryDate fields to have the defined Craft timezone set when going through the date helper
+                    $element->$handle = FeedMeDateHelper::parseString($dataValue, null, true);
                     break;
                 case 'enabled':
                 case 'localeEnabled':
@@ -322,7 +324,7 @@ class EntryFeedMeElementType extends BaseFeedMeElementType
         if (count($requiredContent)) {
             $element->setContentFromPost($requiredContent);
         }
-    }    
+    }
 
     private function _prepareParentForElement($fieldData, $sectionId)
     {

--- a/feedme/FeedMe/Helpers/FeedMeDateHelper.php
+++ b/feedme/FeedMe/Helpers/FeedMeDateHelper.php
@@ -9,7 +9,7 @@ class FeedMeDateHelper
     // Public Methods
     // =========================================================================
 
-    public static function parseString($date, $formatting = 'auto')
+    public static function parseString($date, $formatting = 'auto', $useTimezone = null)
     {
         $parsedDate = null;
 
@@ -68,7 +68,16 @@ class FeedMeDateHelper
             if ($dt) {
                 $dateTimeString = $dt->toDateTimeString();
 
-                $parsedDate = DateTime::createFromString($dateTimeString, craft()->timezone, true);
+                // https://github.com/verbb/feed-me/issues/388
+                // For some reason postDate (and possibly expiryDate) values are sometimes +1 hour than they should be, but it doesn't happen consistently
+                // Debugging the date helper it is when createFromString is used on the postDate/expiryDate value without a timezone.
+                // Problem is when using craft()->timezone on other date fields (not Craft defaults) this causes -1 hour differences. WTF.
+                if ($useTimezone) {
+                    $parsedDate = DateTime::createFromString($dateTimeString, craft()->timezone);
+                }
+                else {
+                    $parsedDate = DateTime::createFromString($dateTimeString, null, true);
+                }
             }
         } catch (\Exception $e) {
             FeedMePlugin::log('Date parse error: ' . $date . ' - ' . $e->getMessage(), LogLevel::Error, true);


### PR DESCRIPTION
This relates to #380 and #388. This forces the built in Craft `postDate` and `expiryDate` date fields to go through the FeedMe Date Helper with `craft()->timezone` used on the output, while leaving other date fields under the original fix made by @kevinsmith in #236.

This seems like a hack, but for whatever reason I am getting inconsistent postDate values imported into Craft with times being +1 on only some imported items, setting the timezone seems to fix the ambiguity, even though most of my imported records are fine without it.

However I have discovered that using `craft()->timezone` across all of the date fields causes issues with those date/time fields, so this only is done on the Craft `postDate` and `expiryDate` fields. It requires a third optional parameter to the FeedMeDateHelper to pull it off.