### PR TITLE
Prevent redirect call if plugin is installed from CLI

### DIFF
--- a/src/FeedMe.php
+++ b/src/FeedMe.php
@@ -50,6 +50,9 @@ class FeedMe extends Plugin
 
     public function afterInstall()
     {
+        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+            return;
+        }
         Craft::$app->controller->redirect(UrlHelper::cpUrl('feed-me/welcome'))->send();
     }
 


### PR DESCRIPTION
This change will prevent an error if you install the feed-me plugin from CLI (`./craft install/plugin feed-me` or via a plugin like schematic).

Before change:
```
./craft install/plugin feed-me             
*** installing feed-me
    > create table {{%feedme_feeds}} ... done (time: 0.017s)
*** failed to install feed-me: Calling unknown method: craft\console\controllers\InstallController::redirect()
```

After change:
```
./craft install/plugin feed-me
*** installing feed-me
    > create table {{%feedme_feeds}} ... done (time: 0.014s)
*** installed feed-me successfully (time: 0.034s)
```