### PR TITLE
Allows SELECT_DATES to be imported.

### DIFF
--- a/src/elements/CalenderEvent.php
+++ b/src/elements/CalenderEvent.php
@@ -30,6 +30,7 @@ class CalenderEvent extends Element implements ElementInterface
 
     public $element;
     private $rruleInfo = [];
+    private $selectDates = [];
 
 
     // Templates
@@ -58,6 +59,9 @@ class CalenderEvent extends Element implements ElementInterface
     {
         Event::on(Process::class, Process::EVENT_STEP_BEFORE_ELEMENT_SAVE, function(FeedProcessEvent $event) {
             $this->_onBeforeElementSave($event);
+        });
+        Event::on(Process::class, Process::EVENT_STEP_AFTER_ELEMENT_SAVE, function(FeedProcessEvent $event) {
+            $this->_onAfterElementSave($event);
         });
     }
 
@@ -196,11 +200,15 @@ class CalenderEvent extends Element implements ElementInterface
         }
     }
 
+    protected function parseSelectDates($feedData, $fieldInfo) {
+        $value = $this->fetchArrayValue($feedData, $fieldInfo);
+        $this->selectDates = $value;
+    }
 
 
     // Private Methods
     // =========================================================================
-    
+
     private function _parseDate($feedData, $fieldInfo)
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
@@ -215,7 +223,7 @@ class CalenderEvent extends Element implements ElementInterface
     }
 
     private function _onBeforeElementSave($event)
-    {   
+    {
         // We prepare rrule info earlier on
         foreach ($this->rruleInfo as $key => $value) {
             $event->element->$key = $value;
@@ -224,4 +232,14 @@ class CalenderEvent extends Element implements ElementInterface
             $event->contentData[$key] = $value;
         }
     }
+
+    private function _onAfterElementSave($event)
+    {
+        if(sizeof($this->selectDates)) {
+            $EventElement = EventElement::find()->id($event->element->id)->one();
+            Calendar::getInstance()->selectDates->saveDates($EventElement, $this->selectDates);
+        }
+    }
+
+
 }

--- a/src/templates/_includes/elements/calendar-event/map.html
+++ b/src/templates/_includes/elements/calendar-event/map.html
@@ -126,35 +126,44 @@
     },
 }, {
     name: 'Until' | t,
-    handle: 'until',    
+    handle: 'until',
     default: {
         type: 'text',
     },
 }, {
     name: 'By Month' | t,
-    handle: 'byMonth',    
+    handle: 'byMonth',
     default: {
         type: 'text',
     },
 }, {
     name: 'By Year Day' | t,
-    handle: 'byYearDay',    
+    handle: 'byYearDay',
     default: {
         type: 'text',
     },
 }, {
     name: 'By Month Day' | t,
-    handle: 'byMonthDay',    
+    handle: 'byMonthDay',
     default: {
         type: 'text',
     },
 }, {
     name: 'By Day' | t,
-    handle: 'byDay',    
+    handle: 'byDay',
     default: {
         type: 'text',
     },
-}] %}
+}, {
+    name: 'Select Dates' | t,
+    handle: 'selectDates',
+    default: {
+        type: 'text',
+    },
+}
+
+
+] %}
 
 <h2>{{ 'Recurrence Fields' | t('feed-me') }}</h2>
 
@@ -193,7 +202,7 @@
                 {% set template = fieldClass.getMappingTemplate() %}
 
                 {% set variables = { name: field.name, handle: field.handle, feed: feed, feedData: feedData, field: field, fieldClass: fieldClass } %}
-                
+
                 {% include template ignore missing with variables only %}
             {% endfor %}
         </tbody>


### PR DESCRIPTION
This allows Solspace Calendar's "SELECT_DATES" data to be imported.

A couple of notes on this:

1. Required the "Repeat Frequency" to be set to "SELECT_DATES"
2. The import assumes an array for the "SELECT_DATES" data
3. Date format for each "SELECT_DATES" date needs to be: YYYY-MM-DD

To dos:

1. It should probably check that "Repeat Frequency" is "SELECT_DATES" before processing this data.
2. Please check the "_onAfterElementSave" function is using the best method for finding the corresponding event element.
3. Could allow the user to specify the date format of "SELECT_DATES" dates.