### PR TITLE
Revert "Feed process event can actually modify variables"

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -141,8 +141,8 @@ class Process extends Component
         }
 
         // Allow event to modify variables
-        $this->_feed = $event->feed;
-        $this->_data = $event->feedData;
+        $feed = $event->feed;
+        $feedData = $event->feedData;
 
         FeedMe::info('Finished preparing for feed processing.');
 


### PR DESCRIPTION
Reverts verbb/feed-me#457

I'm really sorry @engram-design, it seems like this actually broke things. I'm not exactly sure what I've done, but I think what is sent to the event is not matching what comes back and it's preventing feeds from being processed. I'm reverting this immediately until you can get a chance to look at it.